### PR TITLE
[WIP] Saving media to public directory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.dozingcatsoftware.vectorcamera"
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 33
         renderscriptTargetApi 23
         versionCode 13
         versionName "1.6.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         android:requestLegacyExternalStorage="true">
 
         <activity android:name="com.dozingcatsoftware.vectorcamera.MainActivity"
-                  android:configChanges="orientation|screenSize|keyboard|keyboardHidden">
+                  android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -50,7 +51,8 @@
         </activity>
 
         <receiver android:name="com.dozingcatsoftware.vectorcamera.NewPictureReceiver" android:label="NewPictureReceiver"
-            android:enabled="false">
+            android:enabled="false"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.hardware.action.NEW_PICTURE" />
                 <data android:mimeType="image/*" />

--- a/app/src/main/java/com/dozingcatsoftware/vectorcamera/MainActivity.kt
+++ b/app/src/main/java/com/dozingcatsoftware/vectorcamera/MainActivity.kt
@@ -399,7 +399,7 @@ class MainActivity : AppCompatActivity() {
         saveIndicator.show()
         (Thread {
             try {
-                val photoId = photoLibrary.savePhoto(this, pb)
+                val photoId = photoLibrary.savePhoto(applicationContext, pb)
                 saveIndicator.dismiss()
                 handler.post {
                     ViewImageActivity.startActivityWithImageId(this, photoId)

--- a/app/src/main/java/com/dozingcatsoftware/vectorcamera/ViewImageActivity.kt
+++ b/app/src/main/java/com/dozingcatsoftware/vectorcamera/ViewImageActivity.kt
@@ -317,7 +317,7 @@ class ViewImageActivity : Activity() {
 
     private fun deleteImage(view: View) {
         val deleteFn = { _: DialogInterface, _: Int ->
-            photoLibrary.deleteItem(imageId)
+            photoLibrary.deleteItem(this, imageId)
             finish()
         }
 


### PR DESCRIPTION
Images are saved to DCIM directory

Deleting image from app gallery deletes image from DCIM directory

[WIP] Videos are saved to the DCIM directory, however video is being "copied" to the shared directory, but still exists in the app directory, also the copied video is garbled and sometimes unplayable. Also the video effects appear to only be applied in realtime to the raw video when it's played inside the app.

- [x] Save Images to DCIM directory
- [ ] Save Videos to DCIM directory
- [x] Deleting image from app gallery should delete image from DCIM directory
- [ ] Deleting video from app gallery should delete video from DCIM directory
- [ ] Exporting image from app gallery should get image from MediaStore
- [ ] Exporting video from app gallery should get video from MediaStore
- [ ] App gallery should stay synced with media from DCIM directory
- [ ] Update migration tool
- [ ] upon completion, test on Android M (sdk 23) to determine if the (sdk > Android Q) restriction should be lifted

